### PR TITLE
Support dynamic port binding for Render deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "4", "app:asgi_app", "--bind", "0.0.0.0:5000"]
+CMD ["sh", "-c", "exec gunicorn -k uvicorn.workers.UvicornWorker -w 4 app:asgi_app --bind 0.0.0.0:${PORT:-5000}"]

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ except ImportError:
     WSGIMiddleware = None
 
 import asyncio
+import os
 from bs4 import BeautifulSoup
 import datetime
 import re
@@ -769,5 +770,6 @@ def start_analysis_background():
     return jsonify({'status': 'success', 'message': f'Análisis iniciado para el partido {match_id}'})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True) # debug=True es útil para desarrollar
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True) # debug=True es útil para desarrollar
 


### PR DESCRIPTION
## Summary
- allow the Flask entry point to honor the PORT environment variable exposed by Render
- update the Dockerfile entrypoint so gunicorn binds to the dynamic PORT when running in Render

## Testing
- python -m compileall app.py modules

------
https://chatgpt.com/codex/tasks/task_e_68e4ff28aaac832d8b98bd8651be9ce5