### PR TITLE
Add Docker build configuration for Render deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.log
+.env
+.git
+.gitignore
+restaurar/
+html_extraer/
+ficheros_soporte/
+*.bat
+TMP*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --upgrade pip \
+    && pip install -r requirements.txt \
+    && python -m playwright install --with-deps chromium
+
+COPY . .
+
+ENV PORT=8000
+
+CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:8000", "--workers", "1", "--threads", "8", "--timeout", "120"]


### PR DESCRIPTION
## Summary
- add a Python-based Dockerfile that installs project dependencies and Playwright before starting Gunicorn
- add a Docker ignore file to keep transient artifacts out of the image context

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e74ec8abac832db9b75727f369dbc4